### PR TITLE
[DRAFT] chore: add Keyring Network integration

### DIFF
--- a/contracts/protocols/interfaces/IKeyringChecker.sol
+++ b/contracts/protocols/interfaces/IKeyringChecker.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0;
+
+/// @title Keyring Checker Interface
+/// @notice Interface for a contract that checks credentials against a Keyring contract.
+interface IKeyringChecker {
+    /**
+     * @notice Checks if an entity has a valid credential and supports legacy interface.
+     * @param policyId The ID of the policy.
+     * @param entity The address of the entity to check.
+     * @return True if the entity has a valid credential, false otherwise.
+     */
+    function checkCredential(uint256 policyId, address entity) external view returns (bool);
+}

--- a/contracts/protocols/vault/vaultT4/adminModule/events.sol
+++ b/contracts/protocols/vault/vaultT4/adminModule/events.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.21;
 
+import { IKeyringChecker } from "../../../interfaces/IKeyringChecker.sol";
+
 abstract contract VaultT4Events {
     /// @notice emitted when the supply rate config is updated
     event LogUpdateSupplyRate(int supplyRate_);
@@ -19,4 +21,8 @@ abstract contract VaultT4Events {
         uint liquidationPenalty_,
         uint borrowFee_
     );
+
+    /// @notice Emitted when a new keyring checker and policy ID are set.
+    event SetKeyringConfig(IKeyringChecker indexed newKeyringChecker, uint256 newKeyringPolicyId);
+
 }

--- a/contracts/protocols/vault/vaultT4/adminModule/main.sol
+++ b/contracts/protocols/vault/vaultT4/adminModule/main.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.21;
 import { FluidVaultAdmin } from "../../vaultTypesCommon/adminModule/main.sol";
 import { ErrorTypes } from "../../errorTypes.sol";
 import { VaultT4Events } from "./events.sol";
+import { IKeyringChecker } from "../../../interfaces/IKeyringChecker.sol";
+
+
 
 /// @notice Fluid Vault protocol Admin Module contract.
 ///         Implements admin related methods to set configs such as liquidation params, rates
@@ -101,5 +104,12 @@ contract FluidVaultT4Admin is FluidVaultAdmin, VaultT4Events {
             (withdrawGap_ << 62) |
             (liquidationPenalty_ << 72) |
             (borrowFee_ << 82);
+    }
+
+    function setKeyringConfig(IKeyringChecker newKeyringChecker, uint256 newKeyringPolicyId) external onlyOwner {
+        keyringChecker = IKeyringChecker(newKeyringChecker);
+        keyringPolicyId = newKeyringPolicyId;
+
+        emit EventsLib.SetKeyringConfig(newKeyringChecker, newKeyringPolicyId);
     }
 }


### PR DESCRIPTION
## Context
Here is a proposal for discussion, to implement whitelisting system of Keyring Network.

The approach is to:
- Adding a modifier to the `deposit`/`mint`, `withdraw` & `redeem` functions to prevent users without credentials from interacting with the main functions.
- Making the address of the KeyringChecker and the PolicyId configurable by the owner of the vault.
- Not performing a credential check if the address of the KeyringChecker is set to address(0).

## Done
- [x] Added `IKeyringChecker` interface that defines the contract responsible for credential verification
- [x] Interface exposes `checkCredential(uint256 policyId, address user)` to verify if a user is whitelisted for a specific policy
- [x] Added `setKeyringConfig(address keyringChecker, uint256 policyId)` function to configure Keyring settings, restricted to owner
- [x] Validates user credentials before allowing deposits using `checkCredential`
- [x] Added tests for:
       - `setKeyringConfig` functions
       - all the guarded functions
